### PR TITLE
Fix delivery_tag string cast

### DIFF
--- a/src/Subscriber/SubscriberMessage.php
+++ b/src/Subscriber/SubscriberMessage.php
@@ -45,6 +45,6 @@ class SubscriberMessage
 
     public function deliveryTag(): string
     {
-        return $this->message()->delivery_info['delivery_tag'];
+        return (string) $this->message()->delivery_info['delivery_tag'];
     }
 }


### PR DESCRIPTION
According to RabbitMq doccumentation, "delivery_tag" can return an integer
https://www.rabbitmq.com/confirms.html